### PR TITLE
Add license tag

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ setup(
     packages=['aladdin_connect'],
     scripts=[],
     description='Python API for controlling Genie garage doors connected to Aladdin Connect devices',
+    license='MIT',
     long_description=long_description,
     long_description_content_type="text/markdown",
     classifiers=[


### PR DESCRIPTION
Allow third-party tools (e. g., PyPI or `pyp2rpm`) to get the license details in a simple way.