### PR TITLE
Add Link_status function 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # aladdin-connect
+
 Python module that allows interacting with Genie Aladdin Connect devices
 
 Note that shared doors are not currently supported, only doors that are owned by your account can be controlled
 
 ## Usage
+
 ```
 from aladdin_connect import AladdinConnectClient
 
@@ -21,4 +23,7 @@ client.open_door(my_door['device_id'], my_door['door_number'])
 
 # Get updated door status
 client.get_door_status(my_door['device_id'], my_door['door_number'])
+
+# Get updated door link status
+client.get_door_link_status(my_door['device_id'], my_door['door_number'])
 ```

--- a/aladdin_connect/__init__.py
+++ b/aladdin_connect/__init__.py
@@ -133,6 +133,6 @@ class AladdinConnectClient:
                 if door["device_id"] == device_id and door["door_number"] == door_number:
                     return door["battery_level"]
         except ValueError as ex:
-            self._LOGGER.error("Aladdin Connect - Unable to get door link status %s", ex)
+            self._LOGGER.error("Aladdin Connect - Unable to get door battery status %s", ex)
         return self.DOOR_STATUS_UNKNOWN
 

--- a/aladdin_connect/__init__.py
+++ b/aladdin_connect/__init__.py
@@ -81,7 +81,8 @@ class AladdinConnectClient:
                         'door_number': door["door_index"],
                         'name': door["name"],
                         'status': self.DOOR_STATUS[door["status"]],
-                        'link_status': self.DOOR_LINK_STATUS[door["link_status"]]
+                        'link_status': self.DOOR_LINK_STATUS[door["link_status"]],
+                        'battery_level': door["battery_level"]
                     })
                 devices.append({
                     'device_id': device["id"],
@@ -125,12 +126,13 @@ class AladdinConnectClient:
             self._LOGGER.error("Aladdin Connect - Unable to get door status %s", ex)
         return self.DOOR_STATUS_UNKNOWN
 
-    def get_door_link_status(self, device_id, door_number):
+    def get_battery_status(self, device_id, door_number):
         try:
             doors = self.get_doors()
             for door in doors:
                 if door["device_id"] == device_id and door["door_number"] == door_number:
-                    return door["link_status"]
+                    return door["battery_level"]
         except ValueError as ex:
             self._LOGGER.error("Aladdin Connect - Unable to get door link status %s", ex)
         return self.DOOR_STATUS_UNKNOWN
+

--- a/aladdin_connect/__init__.py
+++ b/aladdin_connect/__init__.py
@@ -124,3 +124,13 @@ class AladdinConnectClient:
         except ValueError as ex:
             self._LOGGER.error("Aladdin Connect - Unable to get door status %s", ex)
         return self.DOOR_STATUS_UNKNOWN
+
+    def get_door_link_status(self, device_id, door_number):
+        try:
+            doors = self.get_doors()
+            for door in doors:
+                if door["device_id"] == device_id and door["door_number"] == door_number:
+                    return door["link_status"]
+        except ValueError as ex:
+            self._LOGGER.error("Aladdin Connect - Unable to get door link status %s", ex)
+        return self.DOOR_STATUS_UNKNOWN


### PR DESCRIPTION
Allow Home Assistant to detect when the door is not connected by adding get_door_link_status.  
Allow Home Assistant to display the battery level by adding get_battery_status.
Looking to add the link_status to HA available function - showing the door as unavailable when the opener is not connected to the backend.
Also, adding battery level for HA to display.

Will need a release to implement in HA if accepted